### PR TITLE
Fixes internal links to “Code your” section

### DIFF
--- a/tutorials/alexa-skill-tutorial-nodejs/README.md
+++ b/tutorials/alexa-skill-tutorial-nodejs/README.md
@@ -16,7 +16,7 @@ In this Alexa Skill tutorial for beginners, you will learn how to build a projec
 
 To get you started as quickly as possible, we're going to create a simple Skill that responds with "Hello World!"
 
-Please note: This is a tutorial for beginners and explains the essential steps of Alexa Skill development in detail. If you already have experience with Alexa and just want to learn more about how to use Jovo, either skip the first few sections and go right to [Code the Skill](#code-the-skill), or take a look at the [Jovo Documentation](https://www.jovo.tech/docs).
+Please note: This is a tutorial for beginners and explains the essential steps of Alexa Skill development in detail. If you already have experience with Alexa and just want to learn more about how to use Jovo, either skip the first few sections and go right to [Code the Skill](#build-your-skills-code), or take a look at the [Jovo Documentation](https://www.jovo.tech/docs).
 
 ## How Alexa Skills Work
 

--- a/tutorials/google-action-tutorial-nodejs/README.md
+++ b/tutorials/google-action-tutorial-nodejs/README.md
@@ -19,7 +19,7 @@ In this Google Action tutorial for beginners, you will learn how to build an Act
 
 To get you started as quickly as possible, we're going to create a simple Action that responds with "Hello World!"
 
-Please note: This is a tutorial for beginners and explains the essential steps of Google Action development in detail. If you already have experience with Google Home or Google Assistant and just want to learn more about how to use Jovo, either skip the first few sections and go right to [Code the Skill](#code-the-skill), or take a look at the [Jovo Documentation](https://www.jovo.tech/docs).
+Please note: This is a tutorial for beginners and explains the essential steps of Google Action development in detail. If you already have experience with Google Home or Google Assistant and just want to learn more about how to use Jovo, either skip the first few sections and go right to [Code the Action](#build-your-actions-code), or take a look at the [Jovo Documentation](https://www.jovo.tech/docs).
 
 
 ## How Google Actions Work


### PR DESCRIPTION
In both tutorials there is a “Code the Skill” internal link to “Build You Skill’s Code” section however the link is not correct and also in the case of the Action the link is still “Code the Skill” instead of “Code the Action”. This PR fixes that.