### PR TITLE
Add a comment about commenting out conflicting handlers

### DIFF
--- a/courses/project-3-podcast-player/step-2-stream-multiple-files.md
+++ b/courses/project-3-podcast-player/step-2-stream-multiple-files.md
@@ -150,6 +150,13 @@ app.setHandler({
         }
     },
 });
+
+// If you're running this experiment by altering the checked-in copy of
+// app.js, you should also remove or comment out the lines which set
+// separate classes to function as the callback event handlers:
+// app.setAlexaHandler(AlexaHandler);
+// app.setGoogleAssistantHandler(GoogleHandler);
+
 ```
 
 Save the file and run the Jovo Webhook. It's time to test. Open up the Jovo Debugger and press the **LAUNCH** button, but don't forget to change your device back to an Alexa Echo.


### PR DESCRIPTION
I don't know if anyone else has made/will make this mistake, but it seems worth pointing out.

As noted in the discussion, I've found it easier to start by copying the checked-in example into my working directory and modifying that. This is partly because the course material doesn't mention all the dependencies which the Javascript needs to reference, so I wound up copying those from the final code anyway. I'm undecided whether the best answer is to spell those out in the course text, or to alter the course to suggest my approach (or at least to suggest checking out the official version for reference).

If we do have people work by simplifying the checked-in code, it would be nice to have an in-place equivalent of "jovo new" which would restore all the things which are .gitignored but which are needed for development. Current solution is to check out the source, create a new project alongside it, and copy the former into the latter; it works but it's a bit ugly, and again it isn't well documented.